### PR TITLE
Clarify compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version][package-badge]][package-url] [![Build Status][ci-badge]][ci-url] [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://reactjs.org/docs/how-to-contribute.html#your-first-pull-request)
 
-**Compatibility: React Native 0.55**.
+**Compatibility: React Native 0.55 to 0.61.2 and beyond**.
 
 "React Native for Web" makes it possible to run [React
 Native][react-native-url] components and APIs on the web using React DOM. Check


### PR DESCRIPTION
This part of the README confused me and others--so much that some abandoned RNW and we separated. Since then, I've been making RNW apps and libraries with no problems with respect to versions. We' way beyond 0.55.X.

It only just occurred to be that 0.55.X is the minimum, not the max. Since that seems to be the case, this needs updating as it's discouraged many. Even when I had RNW apps running past `0.55`, some peers still told me it wasn't compatible. So this needs clarifying.

If indeed `0.55` is the last, um "totally compatible" version, it should still be said that it works with the latest versions, but doesn't support some features past `0.55`.